### PR TITLE
Switched to AsyncKeyedLock to prevent a slow memory leak.

### DIFF
--- a/JuvoPlayer/JuvoPlayer.csproj
+++ b/JuvoPlayer/JuvoPlayer.csproj
@@ -25,7 +25,7 @@
     <Compile Remove="Common\UI.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.2.0" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.2.1" />
     <PackageReference Include="FFmpegBindings" Version="3.3.6" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />

--- a/JuvoPlayer/JuvoPlayer.csproj
+++ b/JuvoPlayer/JuvoPlayer.csproj
@@ -25,6 +25,7 @@
     <Compile Remove="Common\UI.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.2.0" />
     <PackageReference Include="FFmpegBindings" Version="3.3.6" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />


### PR DESCRIPTION
Currently the concurrent dictionary keeps filling up with SemaphoreSlim objects but never cleaned.